### PR TITLE
Support maven.compiler.target/source properties

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenUtils.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenUtils.java
@@ -49,12 +49,14 @@ public final class MavenUtils {
    */
   @CheckForNull
   public static String getJavaVersion(MavenProject pom) {
-    return getPluginSetting(pom, GROUP_ID_APACHE_MAVEN, MAVEN_COMPILER_PLUGIN, "target", null);
+    String defaultValue = pom.getProperties().getProperty("maven.compiler.target");
+    return getPluginSetting(pom, GROUP_ID_APACHE_MAVEN, MAVEN_COMPILER_PLUGIN, "target", defaultValue);
   }
 
   @CheckForNull
   public static String getJavaSourceVersion(MavenProject pom) {
-    return getPluginSetting(pom, GROUP_ID_APACHE_MAVEN, MAVEN_COMPILER_PLUGIN, "source", null);
+    String defaultValue = pom.getProperties().getProperty("maven.compiler.source");
+    return getPluginSetting(pom, GROUP_ID_APACHE_MAVEN, MAVEN_COMPILER_PLUGIN, "source", defaultValue);
   }
 
   /**


### PR DESCRIPTION
Hi.

According the documentation, the Java source/target version can be set
using the maven.compiler.target and maven.compiler.source properties in pom.xml:
https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#source

The SonarQube Scanner for Maven should consider these properties to set the sonar.java.source.