### PR TITLE
Fix for wrong dependency version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>org.sonarsource.scanner.api</groupId>
       <artifactId>sonar-scanner-api</artifactId>
-      <version>2.7-build645</version>
+      <version>2.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
There is a wrong version number for the sonar-scanner-api in the pom.