### PR TITLE
MSONAR-158 Support attaching sonar plugin to phase

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
+++ b/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
@@ -149,6 +149,11 @@ public class SonarQubeMojo extends AbstractMojo {
 
   /**
    * Is this execution a 'detached' goal run from the cli.  e.g. mvn sonar:sonar
+   *
+   * See <a href="https://maven.apache.org/guides/mini/guide-default-execution-ids.html#Default_executionIds_for_Implied_Executions">
+      Default executionIds for Implied Executions</a>
+   * for explanation of command line execution id.
+   *
    * @return true if this execution is from the command line
    */
   private boolean isDetachedGoal() {
@@ -156,7 +161,11 @@ public class SonarQubeMojo extends AbstractMojo {
   }
 
   /**
-   * Is this project the last project in the reactor
+   * Is this project the last project in the reactor?
+   *
+   * See <a href="http://svn.apache.org/viewvc/maven/plugins/tags/maven-install-plugin-2.5.2/src/main/java/org/apache/maven/plugin/install/InstallMojo.java?view=markup">
+      install plugin</a> for another example of using this technique.
+   *
    * @return true if last project (including only project)
    */
   private boolean isLastProjectInReactor() {

--- a/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
@@ -55,6 +55,7 @@ public class SonarQubeMojoTest {
   private Log mockedLogger;
 
   private SonarQubeMojo getMojo(File baseDir) throws Exception {
+    SonarQubeMojo.readyProjectsCounter.getAndSet(0);
     return (SonarQubeMojo) mojoRule.lookupConfiguredMojo(baseDir, "sonar");
   }
 


### PR DESCRIPTION
For multi-module projects, binding sonar plugin goal to a phase currently causes multiple scanner executions, once for each module in the project.

Delay the scanner execution to the last module for multi-module projects.  Do not delay if the sonar goal is explicit on the command line.