### PR TITLE
Set to a valid URL for the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>sonar-maven-plugin</artifactId>
   <version>3.4-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
+  <url>http://sonarsource.github.io/sonar-scanner-maven/</url>
 
   <name>SonarQube Scanner for Maven</name>
   <description>Trigger SonarQube analysis on Maven projects</description>


### PR DESCRIPTION
This will prevent errors on linkcheck for the plugin.