### PR TITLE
Add 'sonar.failOnError' property

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
+++ b/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
@@ -62,6 +62,14 @@ public class SonarQubeMojo extends AbstractMojo {
   @Parameter(alias = "sonar.skip", property = "sonar.skip", defaultValue = "false")
   private boolean skip;
 
+  /**
+   * Set this to 'false' to ignore failures and errors encountered during analysis.
+   *
+   * @since 3.5
+   */
+  @Parameter(alias = "sonar.failOnError", property = "sonar.failOnError", defaultValue = "true")
+  private boolean failOnError;
+
   @Component
   private LifecycleExecutor lifecycleExecutor;
 
@@ -105,7 +113,7 @@ public class SonarQubeMojo extends AbstractMojo {
     }
 
     EmbeddedScanner runner = runnerFactory.create();
-    new ScannerBootstrapper(getLog(), session, runner, mavenProjectConverter, propertyDecryptor).execute();
+    new ScannerBootstrapper(getLog(), session, runner, mavenProjectConverter, propertyDecryptor, failOnError).execute();
   }
 
   /**

--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
@@ -41,13 +41,15 @@ public class ScannerBootstrapper {
   private final MavenProjectConverter mavenProjectConverter;
   private String serverVersion;
   private PropertyDecryptor propertyDecryptor;
+  private final boolean failOnError;
 
-  public ScannerBootstrapper(Log log, MavenSession session, EmbeddedScanner scanner, MavenProjectConverter mavenProjectConverter, PropertyDecryptor propertyDecryptor) {
+  public ScannerBootstrapper(Log log, MavenSession session, EmbeddedScanner scanner, MavenProjectConverter mavenProjectConverter, PropertyDecryptor propertyDecryptor, boolean failOnError) {
     this.log = log;
     this.session = session;
     this.scanner = scanner;
     this.mavenProjectConverter = mavenProjectConverter;
     this.propertyDecryptor = propertyDecryptor;
+    this.failOnError = failOnError;
   }
 
   public void execute() throws MojoExecutionException {
@@ -64,7 +66,11 @@ public class ScannerBootstrapper {
 
       scanner.execute(collectProperties());
     } catch (Exception e) {
-      throw new MojoExecutionException(e.getMessage(), e);
+      if (failOnError) {
+        throw new MojoExecutionException(e.getMessage(), e);
+      } else {
+        log.warn("A problem was encountered whilst running Sonar analysis", e);
+      }
     }
   }
 

--- a/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
@@ -151,6 +151,12 @@ public class SonarQubeMojoTest {
     assertThat(readProps("target/dump.properties")).contains((entry("sonar.verbose", "true")));
   }
 
+  @Test
+  public void shouldFailOnWarning() throws Exception {
+    executeProject("sample-project", "sonar.failOnError", "false");
+    assertThat(readProps("target/dump.properties")).contains((entry("sonar.failOnError", "false")));
+  }
+
   private File executeProject(String projectName, String... properties) throws Exception {
 
     File baseDir = new File("src/test/resources/org/sonarsource/scanner/maven/SonarQubeMojoTest/" + projectName);


### PR DESCRIPTION
I've suggested this change based on recent experience where many of my Maven builds were failing due to network connectivity issues with SonarQube. 

It didn't seem reasonable to fail builds because analysis could not be performed. I appreciate what I've implemented may be "blunt solution" – feedback is appreciated!

Commit message follows:

> Defaults to 'true', maintaining existing behaviour. When 'false' and the
> the EmbeddedScanner throws an exception, the exception is not propagated
> and is instead logged as a warning.
> 
> Setting the property to false allows the Maven build to succeed despite
> problems that may be encounterted with Sonar, for example network
> connectivity issues/timeouts etc...