### PR TITLE
Fix MavenProjectConverter so it can correctly handle Windows paths

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -465,12 +465,22 @@ public class MavenProjectConverter {
   private List<File> mainSources(MavenProject pom) throws MojoExecutionException {
     Set<String> sources = new LinkedHashSet<>();
     if (MAVEN_PACKAGING_WAR.equals(pom.getModel().getPackaging())) {
-      sources.add(MavenUtils.getPluginSetting(pom, MavenUtils.GROUP_ID_APACHE_MAVEN, ARTIFACTID_MAVEN_WAR_PLUGIN, "warSourceDirectory", "src/main/webapp"));
+      sources.add(MavenUtils.getPluginSetting(
+            pom,
+            MavenUtils.GROUP_ID_APACHE_MAVEN,
+            ARTIFACTID_MAVEN_WAR_PLUGIN,
+            "warSourceDirectory",
+            new File( pom.getBasedir().getAbsolutePath(), "src/main/webapp" ).getAbsolutePath())
+      );
     }
 
-    sources.add(pom.getFile().getPath());
+    sources.add(pom.getFile().getAbsolutePath());
     if (!MAVEN_PACKAGING_POM.equals(pom.getModel().getPackaging())) {
-      sources.addAll(pom.getCompileSourceRoots());
+      pom.getCompileSourceRoots().stream()
+        .map( Paths::get )
+        .map( path -> path.isAbsolute() ? path : pom.getBasedir().toPath().resolve( path ) )
+        .map( Path::toString )
+        .forEach( sources::add );
     }
 
     return sourcePaths(pom, ScanProperties.PROJECT_SOURCE_DIRS, sources);

--- a/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
@@ -149,7 +149,7 @@ public class MavenProjectConverterTest {
       MavenProjectConverter.findCommonParentDir(Paths.get("foo", "bar"), Paths.get("foo2", "bar2"));
       fail("Expected exception");
     } catch (Exception e) {
-      assertThat(e).isInstanceOf(IllegalStateException.class).hasMessage("Unable to find a common parent between two modules baseDir: 'foo/bar' and 'foo2/bar2'");
+      assertThat(e).isInstanceOf(IllegalStateException.class).hasMessageMatching("Unable to find a common parent between two modules baseDir: 'foo.bar' and 'foo2.bar2'");
     }
   }
 


### PR DESCRIPTION
* tests (and probably some arcane project setups) failed when the current
  working directory on windows was on another drive than the project pom.
  This is the case with the testsuite if the project is checked out on
  a drive different from the temp-drive

* fixed os-dependent exception comparison