### PR TITLE
Fix Mojo so it can correctly determine if it runs on the last project

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
+++ b/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
@@ -19,9 +19,9 @@
  */
 package org.sonarsource.scanner.maven;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.plugin.AbstractMojo;
@@ -32,6 +32,7 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.sonarsource.scanner.api.EmbeddedScanner;
 import org.sonarsource.scanner.api.ScanProperties;
@@ -74,11 +75,6 @@ public class SonarQubeMojo extends AbstractMojo {
   @Parameter(defaultValue = "${mojoExecution}", required = true, readonly = true)
   private MojoExecution mojoExecution;
 
-  /**
-   * Wait until reaching the last project before executing sonar when attached to phase
-   */
-  static final AtomicInteger readyProjectsCounter = new AtomicInteger();
-
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (getLog().isDebugEnabled()) {
@@ -113,7 +109,7 @@ public class SonarQubeMojo extends AbstractMojo {
    * @return true if goal is attached to phase and not last in a multi-module project
    */
   private boolean shouldDelayExecution() {
-    return !isDetachedGoal() && isLastProjectInReactor();
+    return !isDetachedGoal() && !isLastProjectInReactor();
   }
 
   /**
@@ -132,13 +128,21 @@ public class SonarQubeMojo extends AbstractMojo {
   /**
    * Is this project the last project in the reactor?
    *
-   * See <a href="http://svn.apache.org/viewvc/maven/plugins/tags/maven-install-plugin-2.5.2/src/main/java/org/apache/maven/plugin/install/InstallMojo.java?view=markup">
-      install plugin</a> for another example of using this technique.
-   *
    * @return true if last project (including only project)
    */
   private boolean isLastProjectInReactor() {
-    return readyProjectsCounter.incrementAndGet() != session.getProjects().size();
+    List<MavenProject> sortedProjects = session.getProjectDependencyGraph().getSortedProjects();
+
+    MavenProject lastProject = sortedProjects.isEmpty()
+          ? session.getCurrentProject()
+          : sortedProjects.get( sortedProjects.size() - 1 );
+
+    if ( getLog().isDebugEnabled() ) {
+      getLog().debug( "Current project: '" + session.getCurrentProject().getName() +
+            "', Last project to execute based on dependency graph: '" + lastProject.getName() + "'" );
+    }
+
+    return session.getCurrentProject().equals( lastProject );
   }
 
   private boolean isSkip(Map<String, String> properties) {

--- a/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
@@ -25,6 +25,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.graph.GraphBuilder;
+import org.apache.maven.model.building.Result;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.assertj.core.data.MapEntry;
@@ -50,7 +53,6 @@ public class SonarQubeMojoTest {
   private Log mockedLogger;
 
   private SonarQubeMojo getMojo(File baseDir) throws Exception {
-    SonarQubeMojo.readyProjectsCounter.getAndSet(0);
     return (SonarQubeMojo) mojoRule.lookupConfiguredMojo(baseDir, "sonar");
   }
 
@@ -156,6 +158,10 @@ public class SonarQubeMojoTest {
     File baseDir = new File("src/test/resources/org/sonarsource/scanner/maven/SonarQubeMojoTest/" + projectName);
     SonarQubeMojo mojo = getMojo(baseDir);
     mojo.getSession().getProjects().get(0).setExecutionRoot(true);
+    mojo.getSession().setAllProjects(mojo.getSession().getProjects());
+
+    Result<? extends ProjectDependencyGraph> result = mojoRule.lookup( GraphBuilder.class ).build( mojo.getSession() );
+    mojo.getSession().setProjectDependencyGraph( result.get() ); // done by maven in a normal execution
 
     mojo.setLog(mockedLogger);
 


### PR DESCRIPTION
* the counting mode used previously is very fragile depending on the
  number of calls made to the plugin.

  An example where it failed is if the plugin is only configured to run
  in the aggregator pom (so the counter never gets past 1).

  As the dependency graph is already computed by maven we can just
  take the last project in order and compare it to the current one.