### PR TITLE
MSONAR-174 Set source and target versions based on release

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/JavaVersionResolver.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/JavaVersionResolver.java
@@ -63,6 +63,17 @@ public class JavaVersionResolver {
    * @return the java version
    */
   @CheckForNull
+  public String getRelease(MavenProject pom) {
+    return MavenUtils.coalesce(getString(pom, "release"), MavenUtils.getPluginSetting(pom, MavenUtils.GROUP_ID_APACHE_MAVEN, MAVEN_COMPILER_PLUGIN, "release", null));
+  }
+
+  /**
+   * Returns the version of Java used by the maven compiler plugin
+   *
+   * @param pom the project pom
+   * @return the java version
+   */
+  @CheckForNull
   public String getTarget(MavenProject pom) {
     return MavenUtils.coalesce(getString(pom, "target"), MavenUtils.getPluginSetting(pom, MavenUtils.GROUP_ID_APACHE_MAVEN, MAVEN_COMPILER_PLUGIN, "target", null));
   }

--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -289,9 +289,18 @@ public class MavenProjectConverter {
   }
 
   private void guessJavaVersion(MavenProject pom, Map<String, String> props) {
+
+    // Get Java release version from maven-compiler-plugin.
+    String version = javaVersionResolver.getRelease(pom);
+    if (version != null) {
+      props.put(JAVA_SOURCE_PROPERTY, version);
+      props.put(JAVA_TARGET_PROPERTY, version);
+      return;
+    }
+
     // See http://jira.codehaus.org/browse/SONAR-2148
     // Get Java source and target versions from maven-compiler-plugin.
-    String version = javaVersionResolver.getSource(pom);
+    version = javaVersionResolver.getSource(pom);
     if (version != null) {
       props.put(JAVA_SOURCE_PROPERTY, version);
     }

--- a/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
@@ -146,6 +146,13 @@ public class SonarQubeMojoTest {
   }
 
   @Test
+  public void should_get_java_release() throws IOException, Exception {
+    executeProject("sample-project-with-compiler-release");
+    assertPropsContains(entry("sonar.java.target", "8"));
+    assertPropsContains(entry("sonar.java.source", "8"));
+  }
+
+  @Test
   public void verbose() throws Exception {
     when(mockedLogger.isDebugEnabled()).thenReturn(true);
     executeProject("project-with-findbugs-reporting");

--- a/src/test/resources/org/sonarsource/scanner/maven/SonarQubeMojoTest/sample-project-with-compiler-release/pom.xml
+++ b/src/test/resources/org/sonarsource/scanner/maven/SonarQubeMojoTest/sample-project-with-compiler-release/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.sonar</groupId>
+  <artifactId>sample-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test project</name>
+  
+  <properties>
+    <sonar.scanner.dumpToFile>target/dump.properties</sonar.scanner.dumpToFile>
+    <sonar.scanner.versionSimulation>5.6</sonar.scanner.versionSimulation>
+    <sonar.host.url2>http://myserver:9000</sonar.host.url2>
+  </properties>
+  
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+   <build>
+    <plugins>
+      <plugin>
+        <artifactId>sonar-maven-plugin</artifactId>
+      </plugin>
+    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.2</version>
+        <configuration>
+          <release>8</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <profiles>
+    <profile>
+      <id>sonar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <sonar.host.url1>http://myserver:9000</sonar.host.url1>
+      </properties>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
JDK 9 introduced a `release` flag for compiling against a specific Java release.
Prefer this parameter for setting Java source and target.

