### PR TITLE
MSONAR-188 Remove explicit classloader masks and rely on the default EmbeddedScanner masks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>org.sonarsource.scanner.api</groupId>
       <artifactId>sonar-scanner-api</artifactId>
-      <version>2.16.2.588</version>
+      <version>2.16.3.1081</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
@@ -52,7 +52,6 @@ public class ScannerBootstrapper {
 
   public void execute() throws MojoExecutionException {
     try {
-      applyMasks();
       scanner.start();
       serverVersion = scanner.serverVersion();
 
@@ -66,26 +65,6 @@ public class ScannerBootstrapper {
     } catch (Exception e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }
-  }
-
-  private void applyMasks() {
-    // Exclude log implementation to not conflict with Maven 3.1 logging impl
-    scanner.mask("org.slf4j.LoggerFactory");
-    // Include slf4j Logger that is exposed by some Sonar components
-    scanner.unmask("org.slf4j.Logger");
-    scanner.unmask("org.slf4j.ILoggerFactory");
-    // MSONAR-122
-    scanner.unmask("org.slf4j.Marker");
-    // Exclude other slf4j classes
-    // .unmask("org.slf4j.impl.")
-    scanner.mask("org.slf4j.");
-    // Exclude logback
-    scanner.mask("ch.qos.logback.");
-    scanner.mask("org.sonar.");
-    // Guava is not the same version in SonarQube classloader
-    scanner.mask("com.google.common");
-    // Include everything else (we need to unmask all extensions that might be passed to the batch)
-    scanner.unmask("");
   }
 
   private Map<String, String> collectProperties()

--- a/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
@@ -130,9 +130,6 @@ public class ScannerBootstrapperTest {
   }
 
   private void verifyCommonCalls() {
-    verify(scanner, atLeastOnce()).mask(anyString());
-    verify(scanner, atLeastOnce()).unmask(anyString());
-
     verify(scanner).start();
     verify(scanner).serverVersion();
     verify(scanner).execute(projectProperties);


### PR DESCRIPTION
Rebased on top of https://github.com/SonarSource/sonar-scanner-maven/tree/MSONAR-192: merger after it