### PR TITLE
MSONAR-208 Add junit-jupiter-api to enable the execution of tests from Intellij

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+      <version>5.10.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <version>5.10.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
       <version>5.10.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>


### PR DESCRIPTION
While the tests run perfectly from the command-line, Intellij refuses to acknowledge the JUnit5 tests without the inclusion of junit-jupiter-api as a test dependency.