### PR TITLE
Fix - Extend maven proxy settings usage to https

### DIFF
--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerFactory.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerFactory.java
@@ -87,6 +87,11 @@ public class ScannerFactory {
       System.setProperty("http.proxyUser", StringUtils.defaultString(activeProxy.getUsername(), ""));
       System.setProperty("http.proxyPassword", StringUtils.defaultString(activeProxy.getPassword(), ""));
       System.setProperty("http.nonProxyHosts", StringUtils.defaultString(activeProxy.getNonProxyHosts(), ""));
+      System.setProperty("https.proxyHost", activeProxy.getHost());
+      System.setProperty("https.proxyPort", String.valueOf(activeProxy.getPort()));
+      System.setProperty("https.proxyUser", StringUtils.defaultString(activeProxy.getUsername(), ""));
+      System.setProperty("https.proxyPassword", StringUtils.defaultString(activeProxy.getPassword(), ""));
+      System.setProperty("https.nonProxyHosts", StringUtils.defaultString(activeProxy.getNonProxyHosts(), ""));
     }
   }
 }

--- a/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerFactoryTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerFactoryTest.java
@@ -85,13 +85,18 @@ class ScannerFactoryTest {
     System.clearProperty("http.proxyUser");
     System.clearProperty("http.proxyPassword");
     System.clearProperty("http.nonProxyHosts");
+    System.clearProperty("https.proxyHost");
+    System.clearProperty("https.proxyPort");
+    System.clearProperty("https.proxyUser");
+    System.clearProperty("https.proxyPassword");
+    System.clearProperty("https.nonProxyHosts");
   }
 
   @Test
   void testProxy() {
     Proxy proxy = new Proxy();
     proxy.setActive(true);
-    proxy.setProtocol("https");
+    proxy.setProtocol("http");
     proxy.setHost("myhost");
     Settings settings = new Settings();
     settings.setProxies(Collections.singletonList(proxy));
@@ -101,6 +106,7 @@ class ScannerFactoryTest {
     ScannerFactory factory = new ScannerFactory(logOutput, log, runtimeInformation, mojoExecution, mavenSession, envProps, propertyDecryptor);
     factory.create();
     assertThat(System.getProperty("http.proxyHost")).isEqualTo("myhost");
+    assertThat(System.getProperty("https.proxyHost")).isEqualTo("myhost");
   }
 
   @Test


### PR DESCRIPTION
## Why this pull request?
While I was reading the code of this project to find an elegant way to pass proxy settings to this maven plugin, I was pleasantly surprised to discover this plugin can read maven configuration to bind proxy settings. The test factory converts maven proxy configuration to java system properties but forgets these properties must be also set for https configurations. The goal of this pull request is to fix this, completing the missing implementation.

## What does this code do?
This code keeps the current proxy detection and just adds the same settings for https. I don't make any distinction with https because maven proxy config uses one active proxy for all kind of requests, where java system properties makes a distinction between them.

---
Pull request requirements:
- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/MSONAR) ticket available, please make your commits and pull request start with the ticket ID (MSONAR-XXXX). 
