### PR TITLE
SCANMAVEN-220 Revert "Make `sonar.maven.scanAll` true by default"

### DIFF
--- a/its/src/test/java/com/sonar/maven/it/suite/MavenTest.java
+++ b/its/src/test/java/com/sonar/maven/it/suite/MavenTest.java
@@ -167,7 +167,6 @@ class MavenTest extends AbstractMavenTest {
     ORCHESTRATOR.executeBuild(build);
 
     // src/main/webapp is analyzed by web and xml plugin
-    // including resources, so one more file (ejb-module/src/main/resources/META-INF/ejb-jar.xml)
     assertThat(getMeasureAsInteger("com.sonarsource.it.samples.jee:parent", "files")).isEqualTo(9);
   }
 

--- a/its/src/test/java/com/sonar/maven/it/suite/MavenTest.java
+++ b/its/src/test/java/com/sonar/maven/it/suite/MavenTest.java
@@ -167,8 +167,8 @@ class MavenTest extends AbstractMavenTest {
     ORCHESTRATOR.executeBuild(build);
 
     // src/main/webapp is analyzed by web and xml plugin
-    // scanning all files, so 2 more files (ejb-module/src/main/resources/META-INF/ejb-jar.xml and web-module/src/main/webapp/index.jsp)
-    assertThat(getMeasureAsInteger("com.sonarsource.it.samples.jee:parent", "files")).isEqualTo(10);
+    // including resources, so one more file (ejb-module/src/main/resources/META-INF/ejb-jar.xml)
+    assertThat(getMeasureAsInteger("com.sonarsource.it.samples.jee:parent", "files")).isEqualTo(9);
   }
 
   /**

--- a/src/it/java-multi-module/verify.groovy
+++ b/src/it/java-multi-module/verify.groovy
@@ -9,4 +9,4 @@ def sources = 'sonar.sources'
 def module1Sources = "org.codehaus.sonar:sample-project-module1.$sources"
 
 assert properties."$module1Sources" == properties."$projectBaseDir" + "/module1/pom.xml"
-assert properties."$sources" == properties."$projectBaseDir" + "/pom.xml" + "," + properties."$projectBaseDir" + "/verify.groovy"
+assert properties."$sources" == properties."$projectBaseDir" + "/pom.xml"

--- a/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
+++ b/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
@@ -140,8 +140,7 @@ public class ScannerBootstrapper {
   }
 
   private static boolean shouldCollectAllSources(Properties userProperties) {
-    String sonarScanAll = userProperties.getProperty(MavenScannerProperties.PROJECT_SCAN_ALL_SOURCES, Boolean.TRUE.toString());
-    return Boolean.TRUE.equals(Boolean.parseBoolean(sonarScanAll));
+    return Boolean.TRUE.equals(Boolean.parseBoolean(userProperties.getProperty(MavenScannerProperties.PROJECT_SCAN_ALL_SOURCES)));
   }
 
   private static String notCollectingAdditionalSourcesBecauseOf(String overriddenProperty) {

--- a/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
+++ b/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
@@ -34,10 +34,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.*;
 import org.sonarsource.scanner.api.EmbeddedScanner;
@@ -155,17 +152,16 @@ class ScannerBootstrapperTest {
   }
 
   @Test
-  void scanAll_property_is_applied_by_default() throws MojoExecutionException {
+  void scanAll_property_is_not_applied_by_default() throws MojoExecutionException {
     // When sonar.scanner.scanAll is not set
     verifyCollectedSources(sourceDirs -> {
-      assertThat(sourceDirs).hasSize(3);
+      assertThat(sourceDirs).hasSize(2);
       assertThat(sourceDirs[0]).endsWith(Paths.get("src", "main", "java").toString());
       assertThat(sourceDirs[1]).endsWith(Paths.get("pom.xml").toString());
-      assertThat(sourceDirs[2]).endsWith(Paths.get("src", "main", "resources", "index.js").toString());
     });
 
-    verify(log, times(1)).info("Parameter sonar.maven.scanAll is enabled. The scanner will attempt to collect additional sources.");
-    verify(scannerBootstrapper, times(1)).collectAllSources(any(), eq(false));
+    verify(log, never()).info("Parameter sonar.maven.scanAll is enabled. The scanner will attempt to collect additional sources.");
+    verify(scannerBootstrapper, never()).collectAllSources(any(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/MSONAR) ticket available, please make your commits and pull request start with the ticket ID (MSONAR-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
