### PR TITLE
BUILD-5760 Update Cirrus CI maven version to 3.8.8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ env:
 # RE-USABLE CONFIGS
 #
 container_definition: &CONTAINER_DEFINITION
-  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-m3.8.6-latest
+  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-m3.8.8-latest
   cluster_name: ${CIRRUS_CLUSTER_NAME}
   region: eu-central-1
   namespace: default


### PR DESCRIPTION
## Changes

- [x] Update Cirrus CI base image to use maven 3.8.8 (3.8.6 base image will no longer be maintained https://github.com/SonarSource/ci-docker-images/pull/43)
