### PR TITLE
SCANMAVEN-241 Prevent the installation of the property-dump-plugin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ build_task:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   script:
     - source cirrus-env BUILD
-    - mvn -f property-dump-plugin/pom.xml -B install
+    - mvn --batch-mode --file property-dump-plugin/pom.xml verify
     - regular_mvn_build_deploy_analyze
   cleanup_before_cache_script:
     - cleanup_maven_repository


### PR DESCRIPTION
[SCANMAVEN-241](https://sonarsource.atlassian.net/browse/SCANMAVEN-241)



[SCANMAVEN-241]: https://sonarsource.atlassian.net/browse/SCANMAVEN-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ