### PR TITLE
SCANMAVEN-239 Update the integration Tests documentation to include the property-dump-plugin

### DIFF
--- a/develop.md
+++ b/develop.md
@@ -32,7 +32,5 @@ For example, in order to debug the test [java-compiler-executable](src/it/java-c
 
 #### Integration Tests
 The Integration tests are located in `its`.
-
-Before running them, you have to package the `property-dump-plugin` by running the following command from the root of the project: `mvn -f property-dump-plugin/pom.xml clean package`. 
-
+Before running them, you have to package the `property-dump-plugin` by running the following command from the root of the project: `mvn -f property-dump-plugin/pom.xml clean package`.
 Then, they can be run as a separate Maven project: `cd its && mvn verify`

--- a/develop.md
+++ b/develop.md
@@ -31,4 +31,8 @@ For example, in order to debug the test [java-compiler-executable](src/it/java-c
 *Note* that you have to run `mvn invoker:install` to debug the latest changes in your code!
 
 #### Integration Tests
-The Integration tests are located in its. Before running them, you have to package the `property-dump-plugin`: `mvn -f property-dump-plugin/pom.xml clean install`. Then, they can be run as a separate Maven project: `cd its && mvn verify`
+The Integration tests are located in `its`.
+
+Before running them, you have to package the `property-dump-plugin`: `mvn -f property-dump-plugin/pom.xml clean package`. 
+
+Then, they can be run as a separate Maven project: `cd its && mvn verify`

--- a/develop.md
+++ b/develop.md
@@ -33,6 +33,6 @@ For example, in order to debug the test [java-compiler-executable](src/it/java-c
 #### Integration Tests
 The Integration tests are located in `its`.
 
-Before running them, you have to package the `property-dump-plugin`: `mvn -f property-dump-plugin/pom.xml clean package`. 
+Before running them, you have to package the `property-dump-plugin` by running the following command from the root of the project: `mvn -f property-dump-plugin/pom.xml clean package`. 
 
 Then, they can be run as a separate Maven project: `cd its && mvn verify`

--- a/develop.md
+++ b/develop.md
@@ -31,4 +31,4 @@ For example, in order to debug the test [java-compiler-executable](src/it/java-c
 *Note* that you have to run `mvn invoker:install` to debug the latest changes in your code!
 
 #### Integration Tests
-The Integration tests are located in its, and they can be run as a separate Maven project: `cd its && mvn verify`
+The Integration tests are located in its. Before running them, you have to package the `property-dump-plugin`: `mvn -f property-dump-plugin/pom.xml clean install`. Then, they can be run as a separate Maven project: `cd its && mvn verify`


### PR DESCRIPTION
[SCANMAVEN-239](https://sonarsource.atlassian.net/browse/SCANMAVEN-239)

Add a new step in develop.md before running Integration Tests: package the property-dump-plugin.

[SCANMAVEN-239]: https://sonarsource.atlassian.net/browse/SCANMAVEN-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ