### PR TITLE
SCANMAVEN-251 Enable promote during nightly build.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,6 @@ env:
 
   ### Project variables
   DEPLOY_PULL_REQUEST: true
-  NIGHTLY_CRON: 'nightly-cron'
 
 #
 # RE-USABLE CONFIGS
@@ -28,9 +27,6 @@ container_definition: &CONTAINER_DEFINITION
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
-
-except_nightly_cron: &EXCEPT_ON_NIGHTLY_CRON
-  only_if: $CIRRUS_CRON != $NIGHTLY_CRON
 
 #
 # TASKS
@@ -128,7 +124,6 @@ promote_task:
   depends_on:
     - qa
   <<: *ONLY_SONARSOURCE_QA
-  <<: *EXCEPT_ON_NIGHTLY_CRON
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 0.5


### PR DESCRIPTION
[SCANMAVEN-251](https://sonarsource.atlassian.net/browse/SCANMAVEN-251)

 If the nightly cron job does not promote, then the last build analyzed by mend is not necessarily the last build promoted. This is a problem when doing release checks.




[SCANMAVEN-251]: https://sonarsource.atlassian.net/browse/SCANMAVEN-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ