### PR TITLE
BUILD-7791: Use cache for orchestrator

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,6 +28,28 @@ container_definition: &CONTAINER_DEFINITION
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
 
+
+orchestrator_cache_definition: &ORCHESTRATOR_CACHE_DEFINITION
+  set_orchestrator_home_script: |
+    # Check if SQ_VERSION exists and create an intermediary variable
+    if [ -n "$SQ_VERSION" ]; then
+        FOLDER="${SQ_VERSION}"
+    else
+        FOLDER="DEFAULT"
+    fi
+
+    CURRENT_MONTH=$(date +"%B")
+    echo "CURRENT_MONTH=${CURRENT_MONTH}" >> $CIRRUS_ENV
+    echo "ORCHESTRATOR_HOME=${CIRRUS_WORKING_DIR}/orchestrator/${FOLDER}/${CURRENT_MONTH}" >> $CIRRUS_ENV
+    echo "FOLDER=${FOLDER}" >> $CIRRUS_ENV
+  mkdir_orchestrator_home_script: |
+    echo "Create dir ${ORCHESTRATOR_HOME} if needed"
+    mkdir -p ${ORCHESTRATOR_HOME}
+  orchestrator_cache:
+    folder: ${ORCHESTRATOR_HOME}
+    fingerprint_script: echo ${FOLDER}-${CURRENT_MONTH}
+    reupload_on_changes: "true"
+
 #
 # TASKS
 #
@@ -115,10 +137,12 @@ qa_task:
         MAVEN_VERSION: 3.2.5
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
+  <<: *ORCHESTRATOR_CACHE_DEFINITION
   qa_script:
     - ./cirrus/cirrus-qa.sh
   cleanup_before_cache_script:
     - cleanup_maven_repository
+    - ./cirrus/clean-orchestrator-cache.sh
 
 promote_task:
   depends_on:

--- a/cirrus/clean-orchestrator-cache.sh
+++ b/cirrus/clean-orchestrator-cache.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$ORCHESTRATOR_HOME" || exit 1
+
+# Find all sonar-application-* JAR files, sort them by version, and list them
+files=$(find . -name "sonar-application-*" | sort --version-sort --field-separator=- --key=3 --reverse)
+
+# Print the files that will be kept (the latest one)
+echo "File that will not be deleted:"
+echo "$files" | head -n 1
+
+# Get the files that will be deleted (all except the latest one)
+files_to_delete=$(echo "$files" | tail -n +2)
+
+echo ""
+if [ -z "$files_to_delete" ]; then
+  echo "No files will be deleted."
+else
+  echo "Files that will be deleted:"
+  echo "$files_to_delete"
+
+  # Delete obsolete sonar-application files
+  echo "$files_to_delete" | xargs -I {} sh -c 'rm -f "{}" && rmdir "$(dirname "{}")" 2>/dev/null || true'
+fi


### PR DESCRIPTION
[BUILD-7791](https://sonarsource.atlassian.net/browse/BUILD-7791)

Part of https://sonarsource.atlassian.net/browse/BUILD-7791
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
--> 

This PR introduces caching of artifacts downloaded by orchestrator in the pipeline. It is necessary to reduce bandwidth consumption from repox.



[BUILD-7791]: https://sonarsource.atlassian.net/browse/BUILD-7791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ