### PR TITLE
SCANMAVEN-282 Update plexus-sec-dispatcher from 1.4 (sonatype) to 2.0 (codehaus) to fix CVE-2017-1000487

### DIFF
--- a/sonar-maven-plugin/pom.xml
+++ b/sonar-maven-plugin/pom.xml
@@ -49,9 +49,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
-      <version>1.4</version>
+      <version>2.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
[SCANMAVEN-282](https://sonarsource.atlassian.net/browse/SCANMAVEN-282)

https://nvd.nist.gov/vuln/detail/cve-2017-1000487

[SCANMAVEN-282]: https://sonarsource.atlassian.net/browse/SCANMAVEN-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ