### PR TITLE
SCANMAVEN-294 Update sonar-scanner-java-library to 3.4.0.514

### DIFF
--- a/sonar-maven-plugin/pom.xml
+++ b/sonar-maven-plugin/pom.xml
@@ -64,13 +64,13 @@
     <dependency>
       <groupId>org.sonarsource.scanner.lib</groupId>
       <artifactId>sonar-scanner-java-library</artifactId>
-      <version>3.3.1.450</version>
+      <version>3.4.0.514</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
+      <version>3.18.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
[SCANMAVEN-294](https://sonarsource.atlassian.net/browse/SCANMAVEN-294)

We also bump up 3.18.0, which is required for release.

[SCANMAVEN-294]: https://sonarsource.atlassian.net/browse/SCANMAVEN-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ