### PR TITLE
SCANMAVEN-300 Ensure the automatic inclusion of ".github" in "sonar.sources" does not take precedence on user properties

### DIFF
--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
@@ -716,6 +716,23 @@ class MavenProjectConverterTest {
   }
 
   @Test
+  void shouldNotIncludeGithubActionFolderWhenUserPropertiesHavePrecedence() throws Exception {
+    Properties userProperties = new Properties();
+    userProperties.setProperty("sonar.sources", "pom.xml");
+
+    File baseDir = temp.toAbsolutePath().toFile();
+    File githubDir = new File(baseDir, ".github");
+    githubDir.mkdirs();
+    MavenProject project = createProject(new Properties(), "jar");
+
+    Map<String, String> props = projectConverter.configure(Collections.singletonList(project), project, userProperties);
+    assertThat(props.get("sonar.sources").split(",")).containsExactly(
+      new File(baseDir, "pom.xml").getAbsolutePath()
+      //  ".github" directory is not present because the user property "sonar.sources" have precedence
+    );
+  }
+
+  @Test
   void shouldNotIncludeGithubActionFolderWhenNotPresent() throws Exception {
     File baseDir = temp.toAbsolutePath().toFile();
     MavenProject project = createProject(new Properties(), "jar");


### PR DESCRIPTION
[SCANMAVEN-300](https://sonarsource.atlassian.net/browse/SCANMAVEN-300)



[SCANMAVEN-300]: https://sonarsource.atlassian.net/browse/SCANMAVEN-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ