### PR TITLE
SCANMAVEN-310 Exclude E2E test projects from sca analysis after move

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     -->
     <gitRepositoryName>sonar-scanner-maven</gitRepositoryName>
     <license.name>GNU LGPL v3</license.name>
-    <sonar.sca.exclusions>its/projects/**,sonar-maven-plugin/src/it/**,sonar-maven-plugin/src/test/projects/**</sonar.sca.exclusions>
+    <sonar.sca.exclusions>e2e/projects/**,sonar-maven-plugin/src/it/**,sonar-maven-plugin/src/test/projects/**</sonar.sca.exclusions>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
[SCANMAVEN-310](https://sonarsource.atlassian.net/browse/SCANMAVEN-310)

We moved the projects with SCANMAVEN-315 but forgot to update the SCA exclusions.

[SCANMAVEN-310]: https://sonarsource.atlassian.net/browse/SCANMAVEN-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ