### PR TITLE
SCANMAVEN-325 Update license header from SonarSource SA to SonarSource Sàrl

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 SonarQube Scanner for Maven
-Copyright (C) 2009-2025 SonarSource SA
+Copyright (C) 2009-2025 SonarSource Sàrl
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/e2e/src/test/java/com/sonar/maven/it/ItUtils.java
+++ b/e2e/src/test/java/com/sonar/maven/it/ItUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/Proxy.java
+++ b/e2e/src/test/java/com/sonar/maven/it/Proxy.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/ProxyAuthenticator.java
+++ b/e2e/src/test/java/com/sonar/maven/it/ProxyAuthenticator.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/suite/AbstractMavenTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/AbstractMavenTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/suite/BootstrapTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/BootstrapTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/suite/JavaTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/JavaTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/suite/LinksTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/LinksTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/suite/MavenTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/MavenTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/e2e/src/test/java/com/sonar/maven/it/suite/ProxyTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/ProxyTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarSource :: E2E :: SonarQube Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>83.0.0.2369</version>
+    <version>84.0.0.3027</version>
   </parent>
 
   <groupId>org.sonarsource.scanner.maven</groupId>

--- a/property-dump-plugin/src/main/java/org/sonar/dump/PropertyDumpPlugin.java
+++ b/property-dump-plugin/src/main/java/org/sonar/dump/PropertyDumpPlugin.java
@@ -1,6 +1,6 @@
 /*
  * property-dump-plugin
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/property-dump-plugin/src/test/java/org/sonar/dump/PropertyDumpPluginTest.java
+++ b/property-dump-plugin/src/test/java/org/sonar/dump/PropertyDumpPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * property-dump-plugin
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/SonarQubeMojo.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/Maven3ToolchainResolver.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/Maven3ToolchainResolver.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenCompilerResolver.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenCompilerResolver.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenPlugin.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenScannerProperties.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenScannerProperties.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenUtils.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/PropertyDecryptor.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/PropertyDecryptor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperFactory.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/SourceCollector.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/SourceCollector.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/SystemWrapper.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/SystemWrapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/ToolchainResolver.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/ToolchainResolver.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/package-info.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/package-info.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/MavenCompilerResolverTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/MavenCompilerResolverTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/SonarQubeMojoTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/TestLog.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/TestLog.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenUtilsTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperFactoryTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperFactoryTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/SourceCollectorTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/SourceCollectorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Maven
- * Copyright (C) 2009-2025 SonarSource SA
+ * Copyright (C) 2009-2025 SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
[SCANMAVEN-325](https://sonarsource.atlassian.net/browse/SCANMAVEN-325)



[SCANMAVEN-325]: https://sonarsource.atlassian.net/browse/SCANMAVEN-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ