### PR TITLE
SCANMAVEN-374 Unpin internal GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       - *download_maven_matrix
       - name: Vault (GITHUB Token)
         id: secrets-gh
-        uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # v3.1.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/licenses-ro token | GITHUB_TOKEN;
@@ -186,7 +186,7 @@ jobs:
       - *download_maven_matrix
       - name: Vault (GITHUB Token)
         id: secrets-gh
-        uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # v3.1.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/licenses-ro token | GITHUB_TOKEN;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@8e22afd670393ed80f489f5dbd517d09ea21d75b
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/slack webhook | slack_webhook;


### PR DESCRIPTION
* Internal Github actions should follow tags. Pinning is unnecessary.
* This PR prepares us for Renovate.