### PR TITLE
SCANMAVEN-332 Support modular-jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,7 @@ jobs:
           mvn
           --projects '!sonar-maven-plugin'
           --activate-profiles e2e
+          -DqaMaven4=true
           -Dsonar.runtimeVersion="${{ matrix.item.sq_version }}"
           -Dmaven.home="${{ steps.download_maven.outputs.maven_it_path }}"
           verify

--- a/e2e/projects/maven4/modular-jar/pom.xml
+++ b/e2e/projects/maven4/modular-jar/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sonar</groupId>
+    <artifactId>Hello2</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.13.0</version>
+            <type>modular-jar</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>4.0.0-beta-4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/e2e/projects/maven4/modular-jar/pom.xml
+++ b/e2e/projects/maven4/modular-jar/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.sonar</groupId>
-    <artifactId>Hello2</artifactId>
+    <artifactId>modular-jar</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>

--- a/e2e/projects/maven4/modular-jar/src/main/java/com/example/Hello.java
+++ b/e2e/projects/maven4/modular-jar/src/main/java/com/example/Hello.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import org.apache.commons.text.StrBuilder;
+import org.apache.commons.text.WordUtils;
+
+public class Hello {
+  public static void main(String[] args) {
+    System.out.println("Hello, " + WordUtils.initials("Ben John Lee") + "!");
+    StrBuilder sb = new StrBuilder();
+    sb.append("Favorite programming language: ");
+    sb.append("Perl");
+    System.out.println(sb);
+  }
+}

--- a/e2e/projects/maven4/modular-jar/src/main/java/module-info.java
+++ b/e2e/projects/maven4/modular-jar/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module com.example {
+  requires org.apache.commons.text;
+}

--- a/e2e/src/test/java/com/sonar/maven/it/suite/Maven4Test.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/Maven4Test.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.spliterator;
 
 /**
  * Tests for features that are only available in Maven 4.

--- a/e2e/src/test/java/com/sonar/maven/it/suite/Maven4Test.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/Maven4Test.java
@@ -1,0 +1,73 @@
+/*
+ * SonarSource :: E2E :: SonarQube Maven
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.maven.it.suite;
+
+import com.sonar.maven.it.ItUtils;
+import com.sonar.orchestrator.build.MavenBuild;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.spliterator;
+
+/**
+ * Tests for features that are only available in Maven 4.
+ */
+@EnabledIfSystemProperty(named = "qaMaven4", matches = "true")
+class Maven4Test extends AbstractMavenTest {
+  private File outputProps;
+
+  @BeforeEach
+  void setUp(@TempDir Path temp) throws Exception {
+    outputProps = temp.resolve("out.properties").toFile();
+    outputProps.createNewFile();
+  }
+
+  /**
+   * Test that dependencies with `<type>modular-jar</type>` are added to `sonar.java.libraries`.
+   */
+  @Test
+  void modularJar() throws IOException {
+    File projectPom = ItUtils.locateProjectPom("maven4/modular-jar");
+    MavenBuild build = MavenBuild.create(projectPom)
+      .setGoals(cleanPackageSonarGoal())
+      .setProperty("sonar.scanner.internal.dumpToFile", outputProps.getAbsolutePath());
+    executeBuildAndAssertWithoutCE(build);
+
+    Properties generatedProps = new Properties();
+    try (var inputStream = new FileInputStream(outputProps)) {
+      generatedProps.load(inputStream);
+    }
+
+    assertThat(generatedProps)
+      .extractingByKey("sonar.java.libraries")
+      .asString()
+      .containsOnlyOnce("commons-text-1.13.0.jar")
+      .containsOnlyOnce("commons-lang3-3.17.0.jar");
+  }
+}

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -486,8 +486,6 @@ public class MavenProjectConverter {
     // Loop over artifacts makes sure we handle `modular-jar` dependencies.
     // Some of them may duplicate classpath elements, so `libraries` needs to be a set to avoid duplicates.
     for (Artifact artifact : pom.getArtifacts()) {
-      // FIXME: Should we check scope (e.g. "compile")?
-      // FIXME: Can the file be relative? (It requires resolving against basedir.)
       if ("modular-jar".equals(artifact.getType()) && artifact.isResolved()) {
         libraries.add(artifact.getFile());
       }

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -488,6 +488,7 @@ public class MavenProjectConverter {
     for (Artifact artifact : pom.getArtifacts()) {
       // FIXME: Should we check scope (e.g. "compile")?
       // FIXME: Can the file be relative? (It requires resolving against basedir.)
+      libraries.add(artifact.getFile());
     }
 
     if (!libraries.isEmpty()) {

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.CiManagement;
 import org.apache.maven.model.IssueManagement;
@@ -469,7 +470,7 @@ public class MavenProjectConverter {
       throw new MojoExecutionException("Unable to populate" + (test ? " test" : "") + " libraries", e);
     }
 
-    List<File> libraries = new ArrayList<>();
+    LinkedHashSet<File> libraries = new LinkedHashSet<>();
     if (classpathElements != null) {
       String outputDirectory = test ? pom.getBuild().getTestOutputDirectory() : pom.getBuild().getOutputDirectory();
       File basedir = pom.getBasedir();
@@ -481,6 +482,15 @@ public class MavenProjectConverter {
         .filter(File::exists)
         .forEach(libraries::add);
     }
+
+    // Loop over artifacts makes sure we handle `modular-jar` dependencies.
+    // Some of them may duplicate classpath elements, so `libraries` needs to be a set to avoid duplicates.
+    for (Artifact artifact : pom.getArtifacts()) {
+      // FIXME: Should we check scope (e.g. "compile")?
+      // FIXME: Can the file be relative? (It requires resolving against basedir.)
+      libraries.add(artifact.getFile());
+    }
+
     if (!libraries.isEmpty()) {
       String librariesValue = MavenUtils.joinAsCsv(toPaths(libraries));
       if (test) {

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -487,6 +487,7 @@ public class MavenProjectConverter {
     // Some of them may duplicate classpath elements, so `libraries` needs to be a set to avoid duplicates.
     for (Artifact artifact : pom.getArtifacts()) {
       if ("modular-jar".equals(artifact.getType()) && artifact.isResolved()) {
+        // getFile() returns the absolute path to the local ~/.m2 repository.
         libraries.add(artifact.getFile());
       }
     }

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -470,7 +470,7 @@ public class MavenProjectConverter {
       throw new MojoExecutionException("Unable to populate" + (test ? " test" : "") + " libraries", e);
     }
 
-    List<File> libraries = new ArrayList<>();
+    LinkedHashSet<File> libraries = new LinkedHashSet<>();
     if (classpathElements != null) {
       String outputDirectory = test ? pom.getBuild().getTestOutputDirectory() : pom.getBuild().getOutputDirectory();
       File basedir = pom.getBasedir();

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -470,7 +470,7 @@ public class MavenProjectConverter {
       throw new MojoExecutionException("Unable to populate" + (test ? " test" : "") + " libraries", e);
     }
 
-    LinkedHashSet<File> libraries = new LinkedHashSet<>();
+    Set<File> libraries = new LinkedHashSet<>();
     if (classpathElements != null) {
       String outputDirectory = test ? pom.getBuild().getTestOutputDirectory() : pom.getBuild().getOutputDirectory();
       File basedir = pom.getBasedir();
@@ -488,7 +488,9 @@ public class MavenProjectConverter {
     for (Artifact artifact : pom.getArtifacts()) {
       // FIXME: Should we check scope (e.g. "compile")?
       // FIXME: Can the file be relative? (It requires resolving against basedir.)
-      libraries.add(artifact.getFile());
+      if ("modular-jar".equals(artifact.getType()) && artifact.isResolved()) {
+        libraries.add(artifact.getFile());
+      }
     }
 
     if (!libraries.isEmpty()) {

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -470,7 +470,7 @@ public class MavenProjectConverter {
       throw new MojoExecutionException("Unable to populate" + (test ? " test" : "") + " libraries", e);
     }
 
-    LinkedHashSet<File> libraries = new LinkedHashSet<>();
+    List<File> libraries = new ArrayList<>();
     if (classpathElements != null) {
       String outputDirectory = test ? pom.getBuild().getTestOutputDirectory() : pom.getBuild().getOutputDirectory();
       File basedir = pom.getBasedir();

--- a/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
+++ b/sonar-maven-plugin/src/main/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverter.java
@@ -488,7 +488,6 @@ public class MavenProjectConverter {
     for (Artifact artifact : pom.getArtifacts()) {
       // FIXME: Should we check scope (e.g. "compile")?
       // FIXME: Can the file be relative? (It requires resolving against basedir.)
-      libraries.add(artifact.getFile());
     }
 
     if (!libraries.isEmpty()) {


### PR DESCRIPTION
Add support for dependencies with `<type>modular-jar</type>`, added in Maven 4, which are always placed in module path.

Implementation:
* Read artifacts and add them to the jars from the classpath to build `sonar.java.libraries`.
* The dependencies of a modular jar are listed both in classpath and artifacts (`MavenProjectConverter.java‎`), so we need to deduplicate files.
* Added a small test project and a new test `Maven4Test` for features introduced in Maven 4.
* In order to run the new test only with Maven 4, we define a system property `qaMaven4` and condition the test on it.

Faling test runs validating the implementation (and the new test):
* Without the loop over artifacts modular jar is skipped: https://github.com/SonarSource/sonar-scanner-maven/actions/runs/26159126357/job/76946437399
* Without deduplication some jars are added twice: https://github.com/SonarSource/sonar-scanner-maven/actions/runs/26157835233/job/76941990864