### PR TITLE
SCANMAVEN-384 Fix QG broken by the new testing rules

### DIFF
--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/MavenProjectConverterTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.scanner.lib.AnalysisProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -150,11 +150,9 @@ class MavenProjectConverterTest {
     assertThat(MavenProjectConverter.findCommonParentDir(temp.resolve(fooBarPath), temp.resolve(dir2)))
       .isEqualTo(temp);
 
-    IllegalStateException exception = assertThrows(IllegalStateException.class,
-      () -> MavenProjectConverter.findCommonParentDir(fooBarPath, dir2)
-    );
-
-    assertThat(exception).hasMessageMatching("Unable to find a common parent between two modules baseDir: 'foo.bar' and 'foo2.bar2'");
+    assertThatThrownBy(() -> MavenProjectConverter.findCommonParentDir(fooBarPath, dir2))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageMatching("Unable to find a common parent between two modules baseDir: 'foo.bar' and 'foo2.bar2'");
   }
 
   @Test
@@ -468,8 +466,8 @@ class MavenProjectConverterTest {
 
     MavenProject project = createProject(pomProps, "jar");
 
-    assertThrows(MojoExecutionException.class, () ->
-      projectConverter.configure(Collections.singletonList(project), project, new Properties()));
+    assertThatThrownBy(() -> projectConverter.configure(Collections.singletonList(project), project, new Properties()))
+      .isInstanceOf(MojoExecutionException.class);
   }
 
   @Test

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperFactoryTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperFactoryTest.java
@@ -66,6 +66,7 @@ class ScannerBootstrapperFactoryTest {
 
   @BeforeEach
   void setUp() {
+    clearProxyProperties();
 
     Properties system = new Properties();
     system.put("system", "value");
@@ -95,8 +96,11 @@ class ScannerBootstrapperFactoryTest {
   }
 
   @AfterEach
-  @BeforeEach
-  void clearProxyProperties() {
+  void tearDown() {
+    clearProxyProperties();
+  }
+
+  private void clearProxyProperties() {
     System.clearProperty("http.proxyHost");
     System.clearProperty("http.proxyPort");
     System.clearProperty("https.proxyHost");

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
@@ -51,7 +51,6 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.inOrder;
@@ -133,10 +132,8 @@ class ScannerBootstrapperTest {
     when(scannerEngineFacade.isSonarQubeCloud()).thenReturn(false);
     when(scannerEngineFacade.getServerVersion()).thenReturn("5.1");
 
-    MojoExecutionException exception = assertThrows(MojoExecutionException.class,
-      () -> scannerBootstrapper.execute());
-
-    assertThat(exception)
+    assertThatThrownBy(() -> scannerBootstrapper.execute())
+      .isInstanceOf(MojoExecutionException.class)
       .hasCauseExactlyInstanceOf(UnsupportedOperationException.class)
       .hasMessage(UNSUPPORTED_BELOW_SONARQUBE_56_MESSAGE);
   }

--- a/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
+++ b/sonar-maven-plugin/src/test/java/org/sonarsource/scanner/maven/bootstrap/ScannerBootstrapperTest.java
@@ -132,7 +132,7 @@ class ScannerBootstrapperTest {
     when(scannerEngineFacade.isSonarQubeCloud()).thenReturn(false);
     when(scannerEngineFacade.getServerVersion()).thenReturn("5.1");
 
-    assertThatThrownBy(() -> scannerBootstrapper.execute())
+    assertThatThrownBy(scannerBootstrapper::execute)
       .isInstanceOf(MojoExecutionException.class)
       .hasCauseExactlyInstanceOf(UnsupportedOperationException.class)
       .hasMessage(UNSUPPORTED_BELOW_SONARQUBE_56_MESSAGE);


### PR DESCRIPTION
----
## Summary by Gitar

- **Test refactoring:**
  - Migrated legacy `assertThrows` usage to `assertThatThrownBy` across `MavenProjectConverterTest` and `ScannerBootstrapperTest`.
  - Fixed incorrect `@BeforeEach` annotation on the `clearProxyProperties` method in `ScannerBootstrapperFactoryTest` by adding a proper `@AfterEach` teardown.

<sub>This will update automatically on new commits.</sub>