### PR TITLE
SCANMAVEN-385 Code Quality reorganization from jvm to CI Experience Squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/quality-jvm-squad
+* @SonarSource/code-quality-ci-experience-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Code ownership:**
  - Update `CODEOWNERS` to transition project responsibility from `quality-jvm-squad` to `code-quality-ci-experience-squad`.

<sub>This will update automatically on new commits.</sub>