### PR TITLE
SCANMAVEN-387 Code Quality Slack channel reorganization

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
-          slack-channel: squad-jvm-notifs
+          slack-channel: ops-ci-experience

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -58,7 +58,7 @@ jobs:
       sqs-integration: false
       branch: ${{ github.event.inputs.branch }}
       pm-email: "jean.jimbo@sonarsource.com"
-      slack-channel: "squad-jvm-releases"
+      slack-channel: "ops-ci-experience"
       verbose: ${{ github.event.inputs.verbose == 'true' }}
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: squad-jvm-releases
+      slackChannel: ops-ci-experience
       # We do not have any inputs if this workflow is triggered by a release event, hence we have to use a fallback for all inputs
       version: ${{ inputs.version || github.event.release.tag_name }}
       releaseId: ${{ inputs.releaseId || github.event.release.id }}

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -21,4 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         uses: SonarSource/gh-action_slack-notify@v1
         with:
-          slackChannel: squad-jvm-notifs
+          slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Workflow configuration:**
  - Updated `slack-channel` and `slackChannel` references from `squad-jvm-notifs` or `squad-jvm-releases` to `ops-ci-experience` in `.github/workflows/`.

<sub>This will update automatically on new commits.</sub>