### PR TITLE
SCANMAVEN-390 Upgrade orchestrator to version 6.3.0

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator-junit5</artifactId>
-      <version>6.0.3.3907</version>
+      <version>6.3.0.4464</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/e2e/src/test/java/com/sonar/maven/it/suite/AbstractMavenTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/AbstractMavenTest.java
@@ -26,7 +26,7 @@ import com.sonar.orchestrator.container.Edition;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit5.OrchestratorExtension;
 import com.sonar.orchestrator.locator.FileLocation;
-import com.sonar.orchestrator.version.Version;
+import com.sonar.orchestrator.util.Version;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/e2e/src/test/java/com/sonar/maven/it/suite/JavaTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/JavaTest.java
@@ -21,7 +21,7 @@ package com.sonar.maven.it.suite;
 
 import com.sonar.maven.it.ItUtils;
 import com.sonar.orchestrator.build.MavenBuild;
-import com.sonar.orchestrator.version.Version;
+import com.sonar.orchestrator.util.Version;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency upgrades:**
  - Updated `sonar-orchestrator-junit5` to version `6.3.0.4464` in `e2e/pom.xml`.
- **Refactoring:**
  - Adjusted imports for `Version` class from `com.sonar.orchestrator.util.Version` in test files `AbstractMavenTest.java` and `JavaTest.java`.

<sub>This will update automatically on new commits.</sub>