### PR TITLE
SCANMAVEN-392 Upgrade jetty test dependencies to version 9.4.58.v20250814

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -13,7 +13,7 @@
   <name>SonarSource :: E2E :: SonarQube Maven</name>
 
   <properties>
-    <jetty.version>9.4.51.v20230217</jetty.version>
+    <jetty.version>9.4.58.v20250814</jetty.version>
     <maven.compiler.release>17</maven.compiler.release>
     <skipTests>true</skipTests>
     <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Upgraded `jetty.version` from `9.4.51.v20230217` to `9.4.58.v20250814` in `e2e/pom.xml`.

<sub>This will update automatically on new commits.</sub>