### PR TITLE
SCANMAVEN-395 Remove scheduled invocation of sonar:sonar shorthand test

### DIFF
--- a/.github/workflows/shorthand-tester.yml
+++ b/.github/workflows/shorthand-tester.yml
@@ -1,8 +1,7 @@
 name: Test mvn sonar:sonar shorthand
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */3 * * *"  # Run every 3 hours, on the hour
+
 jobs:
   test-shorthand:
     defaults:


### PR DESCRIPTION
Now that the relocation mechanism has broken and that we have no plans to restore it[0], this workflow should only be triggered on demand.

[0] https://community.sonarsource.com/t/retiring-the-magic-sonar-sonar-shorthand-of-the-sonarscanner-for-maven/179815
