### PR TITLE
SCANMAVEN-398 Upgrade orchestrator to version 6.4.0

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator-junit5</artifactId>
-      <version>6.3.0.4464</version>
+      <version>6.4.0.4580</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependencies:**
    - Upgraded `sonar-orchestrator-junit5` version from `6.3.0.4464` to `6.4.0.4580` in `e2e/pom.xml`

<sub>This will update automatically on new commits.</sub>