### PR TITLE
SCANMAVEN-397 Upgrade Maven 4 to 4.0.0-rc-6 in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         item:
-          - {maven_version: 4.0.0-rc-5}
+          - {maven_version: 4.0.0-rc-6}
           - {maven_version: 3.9.11}
           - {maven_version: 3.8.9}
           - {maven_version: 3.6.3}
@@ -174,7 +174,7 @@ jobs:
       fail-fast: false
       matrix:
         item:
-          - {sq_version: "LATEST_RELEASE[2026.1]", maven_version: 4.0.0-rc-5}
+          - {sq_version: "LATEST_RELEASE[2026.1]", maven_version: 4.0.0-rc-6}
     runs-on: github-ubuntu-latest-s
     name: E2E Tests Maven 4
     permissions: *read_permissions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         item:
           - {maven_version: 4.0.0-rc-6}
-          - {maven_version: 3.9.11}
+          - {maven_version: 3.9.16}
           - {maven_version: 3.8.9}
           - {maven_version: 3.6.3}
           - {maven_version: 3.5.4}
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:  
         item:
-          - {sq_version: "LATEST_RELEASE", maven_version: 3.9.11}
+          - {sq_version: "LATEST_RELEASE", maven_version: 3.9.16}
           - {sq_version: "LATEST_RELEASE[2025.1]", maven_version: 3.8.9}
           - {sq_version: "LATEST_RELEASE[9.9]", maven_version: 3.2.5, java_version: "java@17"}
     runs-on: github-ubuntu-latest-s


### PR DESCRIPTION
Ensure that we remain compatible with the latest release candidate of Maven 4.
