### PR TITLE
SCANMAVEN-403 Releasability status fails on property-dump-plugin version

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.example.integration</groupId>
       <artifactId>property-dump-plugin</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/e2e/src/test/java/com/sonar/maven/it/suite/AbstractMavenTest.java
+++ b/e2e/src/test/java/com/sonar/maven/it/suite/AbstractMavenTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractMavenTest {
     .addBundledPluginToKeep("sonar-xml-plugin")
     .addBundledPluginToKeep("sonar-html-plugin")
     // This plugin should have been built locally from the property-dump-plugin module
-    .addPlugin(FileLocation.of("../property-dump-plugin/target/property-dump-plugin-1.0-SNAPSHOT.jar"))
+    .addPlugin(FileLocation.of("../property-dump-plugin/target/property-dump-plugin-" + mojoVersion() + ".jar"))
     .build();
 
   protected WsClient wsClient;
@@ -120,7 +120,7 @@ public abstract class AbstractMavenTest {
   }
 
   protected static String sonarGoal() {
-    return "org.sonarsource.scanner.maven:sonar-maven-plugin:" + mojoVersion().toString() + ":sonar -V";
+    return "org.sonarsource.scanner.maven:sonar-maven-plugin:" + mojoVersion() + ":sonar -V";
   }
 
   protected static String[] cleanSonarGoal() {

--- a/property-dump-plugin/pom.xml
+++ b/property-dump-plugin/pom.xml
@@ -12,7 +12,6 @@
 
   <groupId>org.example.integration</groupId>
   <artifactId>property-dump-plugin</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependencies:**
    - Updated `property-dump-plugin` version in `e2e/pom.xml` to use `${project.version}`.

<sub>This will update automatically on new commits.</sub>